### PR TITLE
Add FASTQ validation routine

### DIFF
--- a/WDL/Tasks/File_Validation/malaria_validation/Dockerfile
+++ b/WDL/Tasks/File_Validation/malaria_validation/Dockerfile
@@ -1,0 +1,19 @@
+
+FROM condaforge/mambaforge:23.3.1-0
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN mamba config \
+    --add channels defaults \
+    --add channels bioconda \
+    --add channels conda-forge && \
+    mamba create -n validate_inputs python=3.7.10 -y && \
+    mamba install -n validate_inputs \
+    fastq_utils=0.25.2 \ 
+    seqkit=2.9.0 \
+    -c conda-forge -c bioconda && \
+    mamba clean --all -f -y && \
+    echo "source activate validate_inputs" > ~/.bashrc
+
+ENV PATH=/opt/conda/envs/validate_inputs/bin:$PATH
+ENV PATH=/opt/conda/envs/validate_inputs/bin/python:$PATH
+SHELL ["conda", "run", "-n", "validate_inputs", "/bin/bash", "-c"]

--- a/WDL/Tasks/File_Validation/malaria_validation/LICENSE
+++ b/WDL/Tasks/File_Validation/malaria_validation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Broad Institute
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/WDL/Tasks/File_Validation/malaria_validation/README.md
+++ b/WDL/Tasks/File_Validation/malaria_validation/README.md
@@ -1,0 +1,9 @@
+# FILE VALIDATION
+
+A task that is used to validate inputs for the AmpSeq pipeline.
+
+## Contact
+
+Jorge Eduardo Amaya Romero:
+
+jamayaro@broadinstitute.org

--- a/WDL/Tasks/File_Validation/validate_inputs.wdl
+++ b/WDL/Tasks/File_Validation/validate_inputs.wdl
@@ -1,0 +1,48 @@
+version 1.0
+
+task validate_fastqs {
+    input {
+        File fastq1
+        File fastq2
+        Boolean? use_original_files = true
+    }
+
+    String fq1_prefix = basename(sub(fastq1, "\.fq", "\.fastq"), ".fastq.gz")
+    String fq2_prefix = basename(sub(fastq2, "\.fq", "\.fastq"), ".fastq.gz")
+                                    
+    command <<< 
+    set -euo pipefail
+    # Validate FASTQs
+    fastq_info ~{fastq1} ~{fastq2}
+    # Get basic statistics
+    seqkit stats ~{fastq1} ~{fastq2}
+
+    # Properly pair FASTQs if indicated
+    if [[ "~{use_original_files}" == "true" ]]; then
+        echo "Using original FASTQ files."
+        cp ~{fastq1} ~{fq1_prefix}.fastq.gz
+        cp ~{fastq2} ~{fq2_prefix}.fastq.gz
+    else
+        echo "Pairing FASTQ files."
+        mkdir Paired
+        seqkit pair -1 ~{fastq1} -2 ~{fastq2} -O Paired
+        mv Paired/~{fq1_prefix}.fastq.gz ~{fq1_prefix}.fastq.gz
+        mv Paired/~{fq2_prefix}.fastq.gz ~{fq2_prefix}.fastq.gz
+    fi
+
+    >>>
+    output {
+        File fastq1_o = fq1_prefix + ".fastq.gz"
+        File fastq2_o = fq2_prefix + ".fastq.gz"
+    }
+    
+    runtime {
+        cpu: 1
+        memory: "1 GB"
+		disks: "local-disk 10 HDD"
+		bootDiskSizeGb: 10
+		preemptible: 3
+		maxRetries: 1
+		docker: "jorgeamaya/validate_inputs:v_1_0_0"
+    }
+}

--- a/WDL/Workflows/wdl_ampseq.wdl
+++ b/WDL/Workflows/wdl_ampseq.wdl
@@ -1,5 +1,6 @@
 version 1.0
 
+import "../Tasks/File_Validation/validate_inputs.wdl" as validate_inputs_t
 import "../Tasks/Prepare_Reference_Files/prepare_reference_files.wdl" as prepare_reference_files_t
 import "../Tasks/Contamination_Detection/contamination_detection.wdl" as contamination_detection_t
 import "../Tasks/Cutadapters/cutadapters.wdl" as cutadapters_t
@@ -17,6 +18,9 @@ workflow ampseq {
         File reference_genome
         Array[String] run_id
         File panel_info
+
+        # Optional parameter for using original vs. paired files
+        Boolean? use_original_fastqs = true
 
         # Optional reference files
         File? forward_primers_file
@@ -38,6 +42,15 @@ workflow ampseq {
     # 2 REMOVE File sample_metadata. USERS WILL ALWAYS GET THIS WRONG.
     # 3 ADD FEATURE TO DOWN SAMPLE FILES
     # 4 DISCONTINUE THE MARKERS TABLE?
+
+    scatter (indx0 in range(length(fastq1s))) {
+        call validate_inputs_t.validate_fastqs as t_000_validate_fastqs {
+            input:
+                fastq1 = fastq1s[indx0],
+                fastq2 = fastq2s[indx0],
+                use_original_files = use_original_fastqs
+        }
+    }
 
     call prepare_reference_files_t.prepare_reference_files as t_001_prepare_reference_files {
         input:


### PR DESCRIPTION
- Added fastq validation routine using fastq_utils and seqkit
- Added optional parameter for forcing to use original fastqs (rather than paired fastqs as determined by seqkit pair)

Sources:
- fastq_utils: https://github.com/nunofonseca/fastq_utils
- seqkit: https://bioinf.shenwei.me/seqkit/